### PR TITLE
Pass userData to the setProfileVariables method

### DIFF
--- a/frame-server/server/docs/businessRulesDocumentation.md
+++ b/frame-server/server/docs/businessRulesDocumentation.md
@@ -20,6 +20,7 @@ Must be custom defined for each project.
 
 -   `server`  
 -   `userid`  
+-   `userData`  
 -   `callback`  
 
 Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The profile data object.

--- a/frame-server/server/helperMethods.js
+++ b/frame-server/server/helperMethods.js
@@ -321,7 +321,7 @@ var helperMethods = {};
     const UserData = server.plugins['hapi-mongo-models'].UserData;
 
     //Custom project-defined rule engine calculation, to be saved as part of user data
-    RuleEngine.setProfileVariables(server, userid,   function (profileData) {
+    RuleEngine.setProfileVariables(server, userid, userData, function (profileData) {
       //Also create the userdata record in background.
 
       console.log("profile data found is:");

--- a/frame-server/server/profile/lib/businessRules.js
+++ b/frame-server/server/profile/lib/businessRules.js
@@ -14,11 +14,12 @@ var businessRules = {};
    * Must be custom defined for each project.
    * @params {Object} server The current server instance.
    * @params {string} userid The desired user ID.
+   * @params {Object} userData The user's demographic data as passed from the browser.
    * @params {function} callback The callback function to pass the profile data to.
    * @returns {Object} The profile data object.
    */
 
-  businessRules.setProfileVariables = function (server, userid, callback) {
+  businessRules.setProfileVariables = function (server, userid, userData, callback) {
     const User = server.plugins['hapi-mongo-models'].User;
     const Account = server.plugins['hapi-mongo-models'].Account;
     var profileData = {};
@@ -33,13 +34,13 @@ var businessRules = {};
         console.log("Account found using account id");
         console.log(account);
 
-        profileData = {
+        var profileData = {
           likeCat: 1
         };
 
+        callback(profileData);
       });
 
-      callback(profileData);
     });
 
   };


### PR DESCRIPTION
From HelperMethods.constructAndStoreUserTags method, pass userData to
the BusinessRules.setProfileVariables method so it can be used in
setting the profile data.

Fixed location of call to callback method in setProfileVariables.